### PR TITLE
fix: initialize websocket issuer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "devDependencies": {
         "@lvce-editor/eslint-config": "^18.0.0",
         "@lvce-editor/package-extension": "^3.2.0",
-        "@lvce-editor/server": "^0.96.21",
-        "@lvce-editor/shared-process": "^0.96.21",
+        "@lvce-editor/server": "^0.99.15",
+        "@lvce-editor/shared-process": "^0.99.15",
         "eslint": "^10.8.0",
         "knip": "^6.29.0",
         "prettier": "^3.9.5"
@@ -1514,9 +1514,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.25.0.tgz",
-      "integrity": "sha512-zgpiSbpQgA07YeiQSzApidBUB9DwenxBksXafJbehbxoNXfqNw2tDiZLifd5Y09PGz/cJhebVQCU2jvw55c4SA==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.26.0.tgz",
+      "integrity": "sha512-vh+dSf+oLjS+ekKOnHHDuP8NUSM3ps/Ir15yCJlGDFw82ZqQeWqAiJyIx3Gsa2XDw77ZKDVfxr9wTHgPIaRu3g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1672,9 +1672,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.96.21",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.96.21.tgz",
-      "integrity": "sha512-s/nr2WwWMACL60WHsceDMcfUg35ODH6l/gQJA6IdC2d+VvpcLeQJd6y6y84FbBYAkBliZQ7nSiofq2M8oCNPPg==",
+      "version": "0.99.15",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.99.15.tgz",
+      "integrity": "sha512-p5u9PSZ/+KalknuumzYgdJm7R3pnr19Aq/cdQ6hRHDd1GKyokrkgpYUj6VXCeA92fN3bCOd5LD/zFkVf3dyLZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1688,9 +1688,9 @@
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.11.0.tgz",
-      "integrity": "sha512-g1rGvTIBggaG9emayBczibKs+eOJgkOtbgp3TidDpuSwaX7uJotLBCGJNQyu6QhPPLskmkz1d5L4R+7bOzO/oA==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.12.0.tgz",
+      "integrity": "sha512-fHn8/9SNNsvTXhekJBCHZ24+ZsBHaisjPep7mipuAeWxTUdN6KTyfY9hpleKPv/VOlA1o4ENueQkNFhoFesftw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2036,9 +2036,9 @@
       }
     },
     "node_modules/@lvce-editor/search-process": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.6.1.tgz",
-      "integrity": "sha512-XQfgR8TK0NN5tnkPnu5mlf7oEe66PwxbfJCCxjFD+XbXRtmYJZpUPitAjkZE5p1awl7RrQMJFUin8uC3mfulig==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.7.0.tgz",
+      "integrity": "sha512-eAyrQ8TakmyKXffDy0hDcsKVoZ6du44kos4XFeDnedfsd1znIBrsnF6mMplixMdL619Cd90kTXA739B7QMorRg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2057,14 +2057,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.96.21",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.96.21.tgz",
-      "integrity": "sha512-PtmM5I8+9Po+W6DfGmfeoYkksMT75IAJI+pLcCgS7emE5M3nhOgk79Ktb93Oj6iZ6r9Zu3syFKTKcBS5yOGDww==",
+      "version": "0.99.15",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.99.15.tgz",
+      "integrity": "sha512-WXS0sgVt6UzKTyXTkoGOT8JO5dv6mKfUn+KqAyMmcK/Hq7ug2FdnwlihVDthDt8L9vIR/lk1lr+lm3NKGpRV0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.96.21",
-        "@lvce-editor/static-server": "0.96.21"
+        "@lvce-editor/shared-process": "0.99.15",
+        "@lvce-editor/static-server": "0.99.15"
       },
       "bin": {
         "server": "bin/server.js"
@@ -2074,14 +2074,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.96.21",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.96.21.tgz",
-      "integrity": "sha512-sgxxry/GIK4J37IJe8uBMzkzYYPHN1gsY4GYhOS7zgKis9wmf4f/O+bkjZ3jRybcqrsMfY9ljEF+Acrz0TRUeQ==",
+      "version": "0.99.15",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.99.15.tgz",
+      "integrity": "sha512-KJ1wKvbZ/pQYqmH14eBSwces4L83tNrUqSD/ude4icmojyextS10IgMw6DEcjCnNB534xLG/9TO1p5QvM0L7hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.96.21",
+        "@lvce-editor/extension-host-helper-process": "0.99.15",
         "@lvce-editor/ipc": "16.10.0",
         "@lvce-editor/json-rpc": "8.6.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -2098,13 +2098,13 @@
       },
       "optionalDependencies": {
         "@lvce-editor/embeds-process": "4.15.0",
-        "@lvce-editor/file-system-process": "5.11.0",
+        "@lvce-editor/file-system-process": "5.12.0",
         "@lvce-editor/file-watcher-process": "4.12.0",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
         "@lvce-editor/pty-host": "8.7.0",
-        "@lvce-editor/search-process": "15.6.1",
+        "@lvce-editor/search-process": "15.7.0",
         "@lvce-editor/typescript-compile-process": "5.8.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
@@ -2113,9 +2113,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.96.21",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.96.21.tgz",
-      "integrity": "sha512-3Zu6j9bMBjOaFJRJHEf9t2QhXrPCqM46/CV6PNL7utqbajR3OHlP+IKDXCoVLEEA7bDfG8zW152kvKXdE7ZQyg==",
+      "version": "0.99.15",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.99.15.tgz",
+      "integrity": "sha512-3DsY2FecidhZM9+tXsRyp3GQBSU2Qa7wJX5a+MZLNJE26UbQvAf0bxmnX2XVvmDP/WKnWhp/TZ8NMx47N/SCGw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10069,9 +10069,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "devDependencies": {
     "@lvce-editor/eslint-config": "^18.0.0",
     "@lvce-editor/package-extension": "^3.2.0",
-    "@lvce-editor/server": "^0.96.21",
-    "@lvce-editor/shared-process": "^0.96.21",
+    "@lvce-editor/server": "^0.99.15",
+    "@lvce-editor/shared-process": "^0.99.15",
     "eslint": "^10.8.0",
     "knip": "^6.29.0",
     "prettier": "^3.9.5"


### PR DESCRIPTION
## Summary
- update `@lvce-editor/server` to a version that initializes the WebSocket issuer
- keep the direct shared-process runtime dependency aligned with the server
- refresh the lockfile and transitive runtime packages

## Validation
- `npm run build`
- `npm run lint`
- started the theme development server
- verified three document responses contain distinct 43-character `webSocketIssuer` values